### PR TITLE
fix(PAYMENT_SERVICE): resolve httpx.ConnectTimeout

### DIFF
--- a/backend/core/paystack.py
+++ b/backend/core/paystack.py
@@ -1,0 +1,4 @@
+class PaystackClient:
+            async with self.client as client:
+                client.timeout = 60  # Increase timeout to 60 seconds
+                rsp = await client.post(


### PR DESCRIPTION
## 🐛 Bug Fix

| Field | Value |
|-------|-------|
| **Component** | `PAYMENT_SERVICE` |
| **Error Type** | `httpx.ConnectTimeout` |
| **Severity** | critical |
| **Impacted Users** | 1500 |
| **Status** | open |

## 📝 Description

Paystack API call timed out during checkout

## 🔍 Problem Identification

The crash occurred during the checkout process when the application tried to initialize a Paystack payment. A `httpx.ConnectTimeout` exception was raised, indicating that the Paystack API call timed out.

## 🎯 Root Cause Analysis

The root cause of the issue is a network or Paystack API problem that is causing the API call to the Paystack service to time out. This is likely due to either connectivity issues between the application and the Paystack API server, or a problem with the Paystack API itself (e.g., high load, downtime, etc.).

## 📊 Data Collection

Stack trace, `paystack.py` file contents, and an analysis of the `PaystackClient` class and `initialize_payment` method.

## 💡 Solution

To fix the issue, the timeout value in the `AsyncClient` initialization in the `PaystackClient` class should be increased from the default to 60 seconds to allow more time for the API call to complete.

## 📎 Supporting Documents

["paystack.py"]

---

**Metadata:**
- 🆔 **Crash ID:** `9f76c615-409e-4bca-9563-a85915cf3d83`
- 🔍 **RCA ID:** `01e192a3-bc66-4db1-8278-62fea9abb4bf`
- 👤 **Author:** None
- 📅 **Created:** 2025-09-12 10:38:44.764104
